### PR TITLE
Use 'main' attribute in package.json

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,5 +1,5 @@
 // Import the add-on.
-var sockittome = require('./build/Release/sockit');
+var sockittome = require('./');
 
 // Create a new sockit object.
 var sockit = new sockittome.Sockit();

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "author": "Ghislain 'Aus' Lacroix <aus@mozilla.com>",
   "description": "A synchronous socket API for node.js.",
 
+  "main": "build/Release/sockit",
+
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
This attribute allows Node to determine the entry point of the module
based on its root directory, making the module easier to consume by
third parties.
