### PR TITLE
Throw errors

### DIFF
--- a/src/sockit.cc
+++ b/src/sockit.cc
@@ -89,19 +89,19 @@ Sockit::Connect(const Arguments& aArgs) {
   HandleScope scope;
 
   if(aArgs.Length() < 1) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Not enough arguments."))
     );
   }
 
   if(aArgs.Length() > 1) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Too many arguments."))
     );
   }
 
   if(!aArgs[0]->IsObject()) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Invalid argument. Must be an Object."))
     );
   }
@@ -113,7 +113,7 @@ Sockit::Connect(const Arguments& aArgs) {
 
   if(!options->Has(hostKey) ||
      !options->Get(hostKey)->IsString()) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(
         String::New("Object must have 'host' field and it must be a string.")
       )
@@ -122,7 +122,7 @@ Sockit::Connect(const Arguments& aArgs) {
 
   if(!options->Has(portKey) ||
      !options->Get(portKey)->IsNumber()) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(
         String::New("Object must have 'port' field and it must be a number.")
       )
@@ -145,19 +145,19 @@ Sockit::Connect(const Arguments& aArgs) {
       // Check h_errno, we might retry if the error indicates we should.
       switch(h_errno) {
         case HOST_NOT_FOUND:
-          return scope.Close(
+          return ThrowException(
             Exception::Error(String::New("Couldn't resolve host."))
           );
         break;
 
         case NO_RECOVERY:
-          return scope.Close(
+          return ThrowException(
             Exception::Error(String::New("Unexpected failure during host lookup."))
           );
         break;
 
         case NO_DATA:
-          return scope.Close(
+          return ThrowException(
             Exception::Error(String::New("Host exists but has no address."))
           );
         break;
@@ -172,14 +172,14 @@ Sockit::Connect(const Arguments& aArgs) {
   while(shouldRetry && retryCount <= MAX_LOOKUP_RETRIES);
 
   if(hostEntry == NULL) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Couldn't resolve host even after retries."))
     );
   }
 
   int socketHandle = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
   if(socketHandle < 0) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Failed to create socket."))
     );
   }
@@ -206,7 +206,7 @@ Sockit::Connect(const Arguments& aArgs) {
     // In case there's another connect attempt, clean up the socket data.
     sockit->mSocket = 0;
     // Report failure to connect.
-    return scope.Close(Exception::Error(String::New("Failed to connect.")));
+    return ThrowException(Exception::Error(String::New("Failed to connect.")));
   }
 
   return aArgs.This();
@@ -217,7 +217,7 @@ Sockit::Read(const Arguments& aArgs) {
   HandleScope scope;
 
   if(aArgs.Length() != 1) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(
         String::New("Not enough arguments, read takes the number of bytes to be read from the socket.")
       )
@@ -225,7 +225,7 @@ Sockit::Read(const Arguments& aArgs) {
   }
 
   if(!aArgs[0]->IsNumber()) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Argument must be a Number."))
     );
   }
@@ -234,7 +234,7 @@ Sockit::Read(const Arguments& aArgs) {
 
   // Make sure we're connected to something.
   if(sockit->mSocket == 0) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(
         String::New("Not connected. To read data you must call connect first.")
       )
@@ -253,7 +253,7 @@ Sockit::Read(const Arguments& aArgs) {
     bytesRead = recv(sockit->mSocket, &buffer[totalBytesRead], bytesToRead, 0);
 
     if(bytesRead < 0) {
-      scope.Close(
+      ThrowException(
           Exception::Error(String::New("Error while reading from socket!"))
       );
     }
@@ -295,13 +295,13 @@ Sockit::Write(const Arguments& aArgs) {
   HandleScope scope;
 
   if(aArgs.Length() < 1) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Not enough arguments."))
     );
   }
 
   if(aArgs.Length() > 1) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(String::New("Too many arguments."))
     );
   }
@@ -310,7 +310,7 @@ Sockit::Write(const Arguments& aArgs) {
 
   // Make sure we're connected to something.
   if(sockit->mSocket == 0) {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(
         String::New("Not connected. To write data you must call connect first.")
       )
@@ -333,7 +333,7 @@ Sockit::Write(const Arguments& aArgs) {
         sockit->Write(node::Buffer::Data(buffer), node::Buffer::Length(buffer));
   }
   else {
-    return scope.Close(
+    return ThrowException(
       Exception::Error(
         String::New("Invalid argument, must be a 'String' or 'Buffer' object.")
       )

--- a/test/sockit_test.js
+++ b/test/sockit_test.js
@@ -69,26 +69,66 @@ suite("Sockit Tests", function() {
 
     suite('argument shape errors', function() {
       test('not enough arguments', function() {
-        assert.ok(subject.connect() instanceof Error);
+        var err;
+
+        try {
+          assert.ok(subject.connect() instanceof Error);
+        } catch(e) {
+          err = e;
+        }
+
+        assert.ok(err instanceof Error);
       });
 
       test('argument of wrong type', function() {
-        assert.ok(subject.connect(23) instanceof Error);
+        var err;
+
+        try {
+          assert.ok(subject.connect(23) instanceof Error);
+        } catch(e) {
+          err = e;
+        }
+
+        assert.ok(err instanceof Error);
       });
 
       test('argument without string "host" attribute', function() {
-        assert.ok(subject.connect({ port: 23 }) instanceof Error);
+        var err;
+
+        try {
+          subject.connect({ port: 23 });
+        } catch(e) {
+          err = e;
+        }
+
+        assert.ok(err instanceof Error);
       });
 
       test('argument without number "port" attribute', function() {
-        assert.ok(subject.connect({ host: 'host' }) instanceof Error);
+        var err;
+
+        try {
+          subject.connect({ host: 'host' });
+        } catch(e) {
+          err = e;
+        }
+
+        assert.ok(err instanceof Error);
       });
     });
 
-    test('error is returned when connection cannot be established',
+    test('error is thrown when connection cannot be established',
       function() {
-      var result = subject.connect({ host: host + 'garbage', port: port });
-      assert.ok(result instanceof Error);
+      var err;
+
+      // Connect throws on error and is synchronous.
+      try {
+        subject.connect({ host: host + 'garbage', port: port });
+      } catch(e) {
+        err = e;
+      }
+
+      assert.ok(err instanceof Error);
     });
   });
 
@@ -116,13 +156,29 @@ suite("Sockit Tests", function() {
       subject.connect({ host: host, port: port });
     });
 
-    test('error is returned when not connected', function() {
-      assert.ok(subject.read(1));
+    test('error is thrown when not connected', function() {
+      var err;
+
+      try {
+        subject.read(1);
+      } catch(e) {
+        err = e;
+      }
+
+      assert.ok(err instanceof Error);
     });
 
-    test('error is returned when a number is not specified', function() {
+    test('error is thrown when a number is not specified', function() {
+      var err;
       subject.connect({ host: host, port: port });
-      assert.ok(subject.read() instanceof Error);
+
+      try {
+        subject.read();
+      } catch(e) {
+        err = e;
+      }
+
+      assert.ok(err instanceof Error);
     });
 
   });
@@ -147,19 +203,42 @@ suite("Sockit Tests", function() {
       subject.connect({ host: host, port: port });
     });
 
-    test('error is returned when not connected', function() {
-      var result = subject.write('data');
-      assert.ok(result instanceof Error);
+    test('error is thrown when not connected', function() {
+      var err;
+
+      try {
+        subject.write('data');
+      } catch(e) {
+        err = e;
+      }
+
+      assert.ok(err instanceof Error);
     });
 
-    test('error is returned when no argument is specified', function() {
+    test('error is thrown when no argument is specified', function() {
+      var err;
       subject.connect({ host: host, port: port });
-      assert.ok(subject.write() instanceof Error);
+
+      try {
+        subject.write();
+      } catch(e) {
+        err = e;
+      }
+
+      assert.ok(err instanceof Error);
     });
 
-    test('error is returned when invalid argument is specified', function() {
+    test('error is thrown when invalid argument is specified', function() {
+      var err;
       subject.connect({ host: host, port: port });
-      assert.ok(subject.write({}) instanceof Error);
+
+      try {
+        subject.write({});
+      } catch(e) {
+        err = e;
+      }
+
+      assert.ok(err instanceof Error);
     });
 
   });


### PR DESCRIPTION
I've been using this module a bit, and I found the following behavior to be somewhat surprising:

``` javascript
var sockittome = require('./');
var sockit = new sockittome.Sockit();
sockit.read(1); // fails "silently"
var err = socket.read(1);
if (err) {
  console.error("Error!", err);
}
```

Usually, Error objects are passed around as values in asynchronous API's (like Node.js's callback-driven API). Since this API is completely synchronous, it's more intuitive to use JavaScript's native Error raising mechanism. This enables more idiomatic usage like:

``` javascript
var sockittome = require('./');
var sockit = new sockittome.Sockit();
try {
  sockit.read(1); // fails "silently"
} catch(err) {
  console.error("Error!", err);
}
```

What do you think?
